### PR TITLE
fix(allow): 🩹 白名单火山引擎方舟域名 (issue #24)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -56,6 +56,7 @@ jobs:
             --adguard-source upstream-adguard \
             --anti-ad-source upstream-anti-ad \
             --coolapk-1007-reward-source upstream-coolapk-1007-reward.txt \
+            --local-allow-source sources/local_allow.txt \
             --output dist \
             --adguard-commit "$ADGUARD_SHA" \
             --anti-ad-commit "$ANTI_AD_SHA" \

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 | [anti-AD](https://github.com/privacy-protection-tools/anti-AD) | Clash payload 广告域 + 例外 |
 | [dead-horse whitelist](https://raw.githubusercontent.com/privacy-protection-tools/dead-horse/master/anti-ad-white-for-clash.yaml) | 并入 allow |
 | [Coolapk 1007 reward](https://raw.githubusercontent.com/lingeringsound/10007/main/reward) | 补充 ads hosts |
+| `sources/local_allow.txt` | 仓库本地白名单，覆盖上游误杀业务域 |
 
 ---
 
@@ -217,6 +218,7 @@ uv run python -m scripts.build_rulesets \
   --adguard-source upstream-adguard \
   --anti-ad-source upstream-anti-ad \
   --coolapk-1007-reward-source upstream-coolapk-1007-reward.txt \
+  --local-allow-source sources/local_allow.txt \
   --output dist \
   --adguard-commit "$(git -C upstream-adguard rev-parse HEAD)" \
   --anti-ad-commit "$(git -C upstream-anti-ad rev-parse HEAD)" \

--- a/scripts/build_rulesets.py
+++ b/scripts/build_rulesets.py
@@ -21,6 +21,7 @@ class BuildArgs:
     adguard_source: Path
     anti_ad_source: Path
     coolapk_1007_reward_source: Path
+    local_allow_source: Path
     output: Path
     adguard_commit: str
     anti_ad_commit: str
@@ -33,6 +34,12 @@ def parse_args(argv: Sequence[str]) -> BuildArgs:
     _ = parser.add_argument("--adguard-source", type=Path, required=True)
     _ = parser.add_argument("--anti-ad-source", type=Path, required=True)
     _ = parser.add_argument("--coolapk-1007-reward-source", type=Path, required=True)
+    _ = parser.add_argument(
+        "--local-allow-source",
+        type=Path,
+        default=Path("sources/local_allow.txt"),
+        help="repo-local AdGuard exception rules merged into allow",
+    )
     _ = parser.add_argument("--output", type=Path, required=True)
     _ = parser.add_argument("--adguard-commit", default="unknown")
     _ = parser.add_argument("--anti-ad-commit", default="unknown")
@@ -43,6 +50,7 @@ def parse_args(argv: Sequence[str]) -> BuildArgs:
     adguard_source = parsed["adguard_source"]
     anti_ad_source = parsed["anti_ad_source"]
     coolapk_1007_reward_source = parsed["coolapk_1007_reward_source"]
+    local_allow_source = parsed["local_allow_source"]
     output = parsed["output"]
     adguard_commit = parsed["adguard_commit"]
     anti_ad_commit = parsed["anti_ad_commit"]
@@ -53,6 +61,8 @@ def parse_args(argv: Sequence[str]) -> BuildArgs:
     if not isinstance(anti_ad_source, Path):
         raise TypeError
     if not isinstance(coolapk_1007_reward_source, Path):
+        raise TypeError
+    if not isinstance(local_allow_source, Path):
         raise TypeError
     if not isinstance(output, Path):
         raise TypeError
@@ -68,6 +78,7 @@ def parse_args(argv: Sequence[str]) -> BuildArgs:
         adguard_source=adguard_source,
         anti_ad_source=anti_ad_source,
         coolapk_1007_reward_source=coolapk_1007_reward_source,
+        local_allow_source=local_allow_source,
         output=output,
         adguard_commit=adguard_commit,
         anti_ad_commit=anti_ad_commit,
@@ -88,6 +99,7 @@ def main() -> int:
             UpstreamKind.DEAD_HORSE: args.dead_horse_commit,
             UpstreamKind.COOLAPK_1007_REWARD: args.coolapk_1007_reward_commit,
         },
+        local_allow_source=args.local_allow_source,
     )
     write_outputs(result, args.output)
     print_summary(result)

--- a/scripts/ruleset_core.py
+++ b/scripts/ruleset_core.py
@@ -23,6 +23,8 @@ def convert_repositories(
     anti_ad_source_dir: Path,
     coolapk_1007_reward_source: Path,
     upstream_commits: dict[UpstreamKind, str],
+    *,
+    local_allow_source: Path,
 ) -> ConversionResult:
     collectors: dict[RuleKind, RuleCollector] = {kind: RuleCollector() for kind in RuleKind}
     stats: dict[RuleKind, ConversionStats] = {kind: ConversionStats() for kind in RuleKind}
@@ -30,6 +32,8 @@ def convert_repositories(
     parse_adguard_magisk(adguard_source_dir, collectors, stats)
     parse_anti_ad(anti_ad_source_dir, collectors, stats)
     parse_coolapk_1007_reward(coolapk_1007_reward_source, collectors, stats)
+    # 本地白名单并入 allow; 不从 ads 删除上游条目, 客户端靠 allow/PASS 优先。
+    parse_local_allow(local_allow_source, collectors, stats)
 
     return ConversionResult(
         buckets={kind: collector.freeze() for kind, collector in collectors.items()},
@@ -67,6 +71,15 @@ def parse_coolapk_1007_reward(
     stats: dict[RuleKind, ConversionStats],
 ) -> None:
     parse_file(source_path, RuleKind.ADS, collectors, stats)
+
+
+def parse_local_allow(
+    source_path: Path,
+    collectors: dict[RuleKind, RuleCollector],
+    stats: dict[RuleKind, ConversionStats],
+) -> None:
+    # 仅接受 @@ 例外; 拦截规则不得经本地白名单文件混入 allow。
+    parse_file(source_path, RuleKind.ALLOW, collectors, stats, exceptions_only=True)
 
 def parse_file(
     path: Path,
@@ -195,6 +208,7 @@ def write_manifest(result: ConversionResult, path: Path) -> None:
         f"- anti-AD: `{result.upstream_commits[UpstreamKind.ANTI_AD]}`",
         f"- dead-horse: `{result.upstream_commits[UpstreamKind.DEAD_HORSE]}`",
         f"- Coolapk 1007 reward: `{result.upstream_commits[UpstreamKind.COOLAPK_1007_REWARD]}`",
+        "- local allow: `sources/local_allow.txt`",
         "",
         "- 产物语义: 多上游 DNS 广告规则到多种客户端格式的保守转换。",
         f"- 例外规则已拆为 `{OUTPUT_PREFIX}_allow.*`, mihomo 建议在 `sub-rules` 中用 `PASS`。",

--- a/sources/local_allow.txt
+++ b/sources/local_allow.txt
@@ -1,0 +1,8 @@
+# HyperADRules 本地白名单（AdGuard 语法）
+# 用于覆盖上游误杀的业务域名；转换时写入 allow 集合，mihomo 建议 PASS。
+#
+# issue #24: Magisk user_rules 含 ||volces.com^$important，整域拦截火山引擎业务域
+# https://github.com/Lynricsy/HyperADRules/issues/24
+@@||ark.cn-beijing.volces.com^
+# 上游 Kimi 例外写成 $importat 会被跳过，这里补正
+@@||prod-chat-kimi.tos-cn-beijing.volces.com^

--- a/tests/test_build_rulesets.py
+++ b/tests/test_build_rulesets.py
@@ -644,7 +644,7 @@ def test_dns_safe_build_does_not_contain_claude_apex(tmp_path: Path) -> None:
         assert "claude.ai" not in content
 
 def test_local_allow_covers_volces_business_domain(tmp_path: Path) -> None:
-    """issue #24: 上游整域 ||volces.com 仍在 ads; 本地白名单把业务域放进 allow。"""
+    """Issue #24: keep ads +.volces.com while allowlisting business hosts."""
     adguard_source = tmp_path / "adguard"
     anti_ad_source = tmp_path / "anti-ad"
     reward_source = tmp_path / "reward.txt"
@@ -657,9 +657,11 @@ def test_local_allow_covers_volces_business_domain(tmp_path: Path) -> None:
     _ = (filters_dir / "1721861844.txt").write_text("@@||safe.example.com^\n", encoding="utf-8")
     # Magisk user_rules 整域拦截 volces.com, 同时含拼写错误的 Kimi 例外。
     _ = (adguard_source / "Adguardhome" / "bin" / "AdGuardHome.yaml").write_text(
-        "user_rules:\n"
-        "  - '||volces.com^$important'\n"
-        "  - '@@||prod-chat-kimi.tos-cn-beijing.volces.com^$importat'\n",
+        (
+            "user_rules:\n"
+            "  - '||volces.com^$important'\n"
+            "  - '@@||prod-chat-kimi.tos-cn-beijing.volces.com^$importat'\n"
+        ),
         encoding="utf-8",
     )
     anti_ad_source.mkdir()
@@ -674,8 +676,10 @@ def test_local_allow_covers_volces_business_domain(tmp_path: Path) -> None:
     )
     _ = reward_source.write_text("0.0.0.0 reward.example.com\n", encoding="utf-8")
     _ = local_allow.write_text(
-        "@@||ark.cn-beijing.volces.com^\n"
-        "@@||prod-chat-kimi.tos-cn-beijing.volces.com^\n",
+        (
+            "@@||ark.cn-beijing.volces.com^\n"
+            "@@||prod-chat-kimi.tos-cn-beijing.volces.com^\n"
+        ),
         encoding="utf-8",
     )
 

--- a/tests/test_build_rulesets.py
+++ b/tests/test_build_rulesets.py
@@ -18,6 +18,12 @@ from scripts.ruleset_types import (
 )
 
 
+def empty_local_allow(tmp_path: Path) -> Path:
+    path = tmp_path / "local_allow.txt"
+    _ = path.write_text("# empty local allow\n", encoding="utf-8")
+    return path
+
+
 def test_parse_domain_block_rule_when_adguard_suffix_rule() -> None:
     collectors = {kind: RuleCollector() for kind in RuleKind}
     stats = {kind: ConversionStats() for kind in RuleKind}
@@ -282,6 +288,7 @@ def test_convert_repositories_when_multiple_upstreams_have_rules(tmp_path: Path)
             UpstreamKind.DEAD_HORSE: "dead-horse-sha256",
             UpstreamKind.COOLAPK_1007_REWARD: "reward-sha256",
         },
+        local_allow_source=empty_local_allow(tmp_path),
     )
 
     assert result.buckets[RuleKind.ADS].domains == {
@@ -554,6 +561,7 @@ def test_write_outputs_emits_multi_format_files(tmp_path: Path) -> None:
             UpstreamKind.DEAD_HORSE: "dead-horse-sha256",
             UpstreamKind.COOLAPK_1007_REWARD: "reward-sha256",
         },
+        local_allow_source=empty_local_allow(tmp_path),
     )
     out = tmp_path / "dist"
     write_outputs(result, out)
@@ -608,6 +616,7 @@ def test_dns_safe_build_does_not_contain_claude_apex(tmp_path: Path) -> None:
             UpstreamKind.DEAD_HORSE: "dead-horse-sha256",
             UpstreamKind.COOLAPK_1007_REWARD: "reward-sha256",
         },
+        local_allow_source=empty_local_allow(tmp_path),
     )
     out = tmp_path / "dist"
     write_outputs(result, out)
@@ -633,3 +642,69 @@ def test_dns_safe_build_does_not_contain_claude_apex(tmp_path: Path) -> None:
         content = (out / relative_name).read_text(encoding="utf-8")
         assert all(token not in content for token in forbidden_tokens)
         assert "claude.ai" not in content
+
+def test_local_allow_covers_volces_business_domain(tmp_path: Path) -> None:
+    """issue #24: 上游整域 ||volces.com 仍在 ads; 本地白名单把业务域放进 allow。"""
+    adguard_source = tmp_path / "adguard"
+    anti_ad_source = tmp_path / "anti-ad"
+    reward_source = tmp_path / "reward.txt"
+    local_allow = tmp_path / "local_allow.txt"
+    filters_dir = adguard_source / "Adguardhome" / "bin" / "data" / "filters"
+    filters_dir.mkdir(parents=True)
+    (adguard_source / "Adguardhome" / "bin").mkdir(exist_ok=True)
+    _ = (filters_dir / "1721861846.txt").write_text("||ads.example.com^\n", encoding="utf-8")
+    _ = (filters_dir / "1735560833.txt").write_text("||bad.example.com^\n", encoding="utf-8")
+    _ = (filters_dir / "1721861844.txt").write_text("@@||safe.example.com^\n", encoding="utf-8")
+    # Magisk user_rules 整域拦截 volces.com, 同时含拼写错误的 Kimi 例外。
+    _ = (adguard_source / "Adguardhome" / "bin" / "AdGuardHome.yaml").write_text(
+        "user_rules:\n"
+        "  - '||volces.com^$important'\n"
+        "  - '@@||prod-chat-kimi.tos-cn-beijing.volces.com^$importat'\n",
+        encoding="utf-8",
+    )
+    anti_ad_source.mkdir()
+    _ = (anti_ad_source / "anti-ad-adguard.txt").write_text("@@||anti-safe.example.com^\n", encoding="utf-8")
+    _ = (anti_ad_source / "anti-ad-clash.yaml").write_text(
+        "payload:\n  - '+.mssdk.volces.com'\n",
+        encoding="utf-8",
+    )
+    _ = (anti_ad_source / "anti-ad-white-for-clash.yaml").write_text(
+        "payload:\n  - '+.anti-white.example.com'\n",
+        encoding="utf-8",
+    )
+    _ = reward_source.write_text("0.0.0.0 reward.example.com\n", encoding="utf-8")
+    _ = local_allow.write_text(
+        "@@||ark.cn-beijing.volces.com^\n"
+        "@@||prod-chat-kimi.tos-cn-beijing.volces.com^\n",
+        encoding="utf-8",
+    )
+
+    result = convert_repositories(
+        adguard_source,
+        anti_ad_source,
+        reward_source,
+        {
+            UpstreamKind.ADGUARD_MAGISK: "adguard-sha",
+            UpstreamKind.ANTI_AD: "anti-sha",
+            UpstreamKind.DEAD_HORSE: "dead-horse-sha256",
+            UpstreamKind.COOLAPK_1007_REWARD: "reward-sha256",
+        },
+        local_allow_source=local_allow,
+    )
+    out = tmp_path / "dist"
+    write_outputs(result, out)
+
+    # ads 仍保留整域拦截与已知广告子域, 不在转换阶段删除。
+    assert "+.volces.com" in result.buckets[RuleKind.ADS].domains
+    assert "+.mssdk.volces.com" in result.buckets[RuleKind.ADS].domains
+    # allow 新增方舟业务域与修正后的 Kimi 例外。
+    assert "+.ark.cn-beijing.volces.com" in result.buckets[RuleKind.ALLOW].domains
+    assert "+.prod-chat-kimi.tos-cn-beijing.volces.com" in result.buckets[RuleKind.ALLOW].domains
+    # 上游 $importat 拼写错误仍被跳过; 白名单来自 local_allow。
+    assert result.stats[RuleKind.ALLOW].unsupported_modifier >= 1
+
+    allow_txt = (out / "hyper_adrules_allow.txt").read_text(encoding="utf-8")
+    ads_txt = (out / "hyper_adrules_ads.txt").read_text(encoding="utf-8")
+    assert "+.ark.cn-beijing.volces.com" in allow_txt.splitlines()
+    assert "+.volces.com" in ads_txt.splitlines()
+


### PR DESCRIPTION
## Summary
- 根因：上游 Magisk `user_rules` 有 `||volces.com^$important`，转换后变成 `+.volces.com`，误杀 `ark.cn-beijing.volces.com`
- 新增 `sources/local_allow.txt`，把业务域并入 **allow** 产物；**不**从 ads 删除整域拦截
- 同步修正上游 Kimi 例外 `$importat` 拼写导致的白名单丢失

## 行为
- allow 新增：`+.ark.cn-beijing.volces.com`、`+.prod-chat-kimi.tos-cn-beijing.volces.com`
- ads 仍保留：`+.volces.com` 及 `mssdk`/`apmplus` 等广告子域
- 客户端按 README：`allow` → `PASS` 优先于 `ads` → `REJECT`

## Test plan
- [x] `uv run pytest`（37 passed）
- [x] 回归：allow 含 `+.ark.cn-beijing.volces.com`，ads 仍含 `+.volces.com`
- [ ] merge 后 workflow_dispatch 重建 latest release

Closes #24

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix false blocking of Volcengine Ark hosts by merging a repo-local allowlist into the allow output while keeping the upstream `volces.com` block in ads. Also restores the Kimi exception lost due to a `$importat` typo.

- **Bug Fixes**
  - Added `sources/local_allow.txt` (exceptions-only) to merge into allow; adds `+.ark.cn-beijing.volces.com` and `+.prod-chat-kimi.tos-cn-beijing.volces.com`.
  - Kept ads entries for `+.volces.com` and known ad subdomains (`mssdk`, `apmplus`); clients rely on allow/PASS priority over ads/REJECT.
  - Introduced `--local-allow-source` in the build script and workflow; manifest notes the local allow source.
  - Expanded tests to cover the new allowlist behavior.

<sup>Written for commit ba7891090020fdfd6da4a96dc771886811353eab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Lynricsy/HyperADRules/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

