### PR TITLE
ci(release): 🐛 去掉重复的 stats.json 上传

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -224,7 +224,6 @@ jobs:
             dist/*.json
             dist/*.conf
             dist/manifest.md
-            dist/stats.json
             dist/SHA256SUMS
           make_latest: true
           # 同 content fingerprint 已完整则跳过; 残缺 release 会先删除再建, 不覆盖 assets。


### PR DESCRIPTION
## Summary
- `dist/*.json` 已包含 `stats.json`，workflow 又显式列了一次
- 配合 `overwrite_files: false` 会在部分上传后失败，留下 draft release

## Test plan
- [x] 本地 diff 确认只删一行重复项
- [ ] merge 后下一次 publish 不再报 `already_exists`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the duplicate `stats.json` in the release workflow (already included by `dist/*.json`) to prevent upload collisions. This avoids `softprops/action-gh-release` failures with `overwrite_files: false` (already_exists) and stops broken draft releases.

<sup>Written for commit 107fcd9c2ecfe013313a9a30112dda74958439c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Lynricsy/HyperADRules/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

